### PR TITLE
Use wand instead of pillow as solr-thumbnail backend

### DIFF
--- a/dejavo/apps/zabo/models.py
+++ b/dejavo/apps/zabo/models.py
@@ -113,7 +113,7 @@ class Article(models.Model):
         poster = {'origin' : None, 'main_thumb' : None, 'category_thumb': None }
         if (bool(self.image)):
             poster['origin'] = self.image.url
-            poster['main_thumb'] = get_thumbnail(self.image, '600').url
+            poster['main_thumb'] = get_thumbnail(self.image, '600', quality=85).url
 
             is_portrait = self.image.width < self.image.height
             to_scale = [222, 321] if is_portrait else [468, 321]
@@ -135,7 +135,7 @@ class Article(models.Model):
 
                 geometry = str(width) + 'x' + str(height)
 
-            poster['category_thumb'] = get_thumbnail(self.image, geometry).url
+            poster['category_thumb'] = get_thumbnail(self.image, geometry, quality=85).url
 
         ctx = {
                 'id' : self.id,
@@ -224,7 +224,7 @@ class Question(models.Model):
 
     def clean(self):
         if self.content.strip() == '':
-            raise ValidationError({'content': 
+            raise ValidationError({'content':
                 'Content should not be empty string'})
 
     def as_json(self):
@@ -270,7 +270,7 @@ class Answer(models.Model):
 
     def clean(self):
         if self.content.strip() == '':
-            raise ValidationError({'content': 
+            raise ValidationError({'content':
                 'Content should not be empty string'})
 
     def as_json(self):

--- a/dejavo/settings.py
+++ b/dejavo/settings.py
@@ -160,6 +160,7 @@ DEFAULT_FROM_EMAIL = 'webmaster@localhost'
 
 
 # Thumbnail
+THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.wand_engine.Engine'
 THUMBNAIL_KVSTORE = 'sorl.thumbnail.kvstores.redis_kvstore.KVStore'
 THUMBNAIL_REDIS_DB = 1
 THUMBNAIL_FORMAT = 'PNG'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django==1.7.2
 Pillow==2.7.0
 PyJWT==0.4.1
+Wand==0.4.0
 argparse==1.2.1
 oauthlib==0.7.2
 python-openid==2.2.5


### PR DESCRIPTION
현재 자보에 떠있는 TEDxKAIST 아인슈타인 이미지 기준으로

* (현재) Pillow + 95% quality일때 848kb
* Wand + 95% quality일때 259kb
* Wand + 90% quality일때 178kb
* Wand + 85% quality일때 142kb

(Pillow일때는 quality 조절이 안 되는 것으로 보입니다.)

Wand로 할 때 이미지 색감이 좀 달라지는 경우가 있고, 초기 cache building에 pillow보다 더 오래 걸리는 게 흠이긴 한데, 어차피 캐시가 빵빵하게 잘 되는 것 같으니 backend engine을 바꾸는 건 어떨지 제안해봅니다.